### PR TITLE
feat: Run the UE container privileged with NET_ADMIN capability

### DIFF
--- a/src/k8s_privileged.py
+++ b/src/k8s_privileged.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module used to set a privileged context for Kubernetes Statefulset containers."""
+
+import logging
+
+from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.core_v1 import (
+    Capabilities,
+    SecurityContext,
+)
+from lightkube.resources.apps_v1 import StatefulSet
+
+logger = logging.getLogger(__name__)
+
+
+class K8sPrivilegedError(Exception):
+    """K8sPrivilegedError."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
+class K8sPrivileged:
+    """Statefulset patcher to run containers in privileged context with NET_ADMIN capability."""
+
+    def __init__(
+        self,
+        namespace: str,
+        statefulset_name: str,
+    ):
+        self.k8s_client = Client()
+        self.statefulset_name = statefulset_name
+        self.namespace = namespace
+
+    def is_patched(self, container_name: str) -> bool:
+        """Check whether the container in the Statefulset runs with the right security context.
+
+        Args:
+            container_name (str): Name of the container to check
+
+        Returns:
+            bool: True if the container is privileged and has net_admin capability, otherwise False
+        """
+        try:
+            statefulset = self.k8s_client.get(
+                res=StatefulSet,
+                name=self.statefulset_name,
+                namespace=self.namespace,
+            )
+            container = next(
+                filter(
+                    lambda ctr: ctr.name == container_name,
+                    statefulset.spec.template.spec.containers,  # type: ignore[reportOptionalMemberAccess]
+                )
+            )
+            if "NET_ADMIN" not in container.securityContext.capabilities.add:  # type: ignore[operator,union-attr]
+                return False
+            if not container.securityContext.privileged:  # type: ignore[reportOptionalMemberAccess]
+                return False
+        except ApiError:
+            raise K8sPrivilegedError(f"Could not get statefulset {self.statefulset_name}")
+        except StopIteration:
+            raise K8sPrivilegedError(f"Could not get container {container_name}")
+        return True
+
+    def patch_statefulset(self, container_name: str) -> None:
+        """Patch the Statefulset to run container in privileged context with NET_ADMIN capability.
+
+        Args:
+            container_name (str): Name of the container to check
+        """
+        try:
+            statefulset = self.k8s_client.get(
+                res=StatefulSet,
+                name=self.statefulset_name,
+                namespace=self.namespace,
+            )
+            container = next(
+                filter(
+                    lambda ctr: ctr.name == container_name,
+                    statefulset.spec.template.spec.containers,  # type: ignore[reportOptionalMemberAccess]
+                )
+            )
+            container.securityContext = SecurityContext(
+                capabilities=Capabilities(
+                    add=[
+                        "NET_ADMIN",
+                    ]
+                )
+            )
+            container.securityContext.privileged = True  # type: ignore[reportOptionalMemberAccess]
+            self.k8s_client.replace(obj=statefulset)
+            logger.info("Container %s patched", container_name)
+        except ApiError:
+            raise K8sPrivilegedError(f"Could not get statefulset {self.statefulset_name}")
+        except StopIteration:
+            raise K8sPrivilegedError(f"Could not get container {container_name}")

--- a/src/k8s_privileged.py
+++ b/src/k8s_privileged.py
@@ -66,6 +66,8 @@ class K8sPrivileged:
             raise K8sPrivilegedError(f"Could not get statefulset {self.statefulset_name}")
         except StopIteration:
             raise K8sPrivilegedError(f"Could not get container {container_name}")
+        except AttributeError:
+            return False
         return True
 
     def patch_statefulset(self, container_name: str) -> None:

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -12,10 +12,12 @@ from charm import OaiRanUeK8SOperatorCharm
 
 class UEFixtures:
     patcher_check_output = patch("charm.check_output")
+    patcher_k8s_privileged = patch("charm.K8sPrivileged")
 
     @pytest.fixture(autouse=True)
     def setUp(self, request):
         self.mock_check_output = UEFixtures.patcher_check_output.start()
+        self.mock_k8s_privileged = UEFixtures.patcher_k8s_privileged.start().return_value
         yield
         request.addfinalizer(self.tearDown)
 

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -76,6 +76,25 @@ class TestCharmCollectStatus(UEFixtures):
 
         assert state_out.unit_status == WaitingStatus("Waiting for Pod IP address to be available")
 
+    def test_given_charm_statefulset_is_not_patched_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
+        self,
+    ):
+        self.mock_k8s_privileged.is_patched.return_value = False
+        self.mock_check_output.return_value = b"1.2.3.4"
+        container = scenario.Container(
+            name="ue",
+            can_connect=True,
+        )
+        state_in = scenario.State(
+            leader=True,
+            relations=[],
+            containers=[container],
+        )
+
+        state_out = self.ctx.run("collect_unit_status", state_in)
+
+        assert state_out.unit_status == WaitingStatus("Waiting for statefulset to be patched")
+
     def test_given_config_file_doesnt_exist_when_collect_status_then_status_is_waiting(self):
         self.mock_check_output.return_value = b"1.2.3.4"
         container = scenario.Container(


### PR DESCRIPTION
# Description

This runs the UE container privileged with NET_ADMIN capability, as the UE needs to create a `tun` interface.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library