### PR TITLE
fix: Adds possibility of setting custom SD (Slice Differentiator)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,7 +45,7 @@ config:
   options:
     imsi:
       type: string
-      default: "208930100007487"
+      default: "001010100007487"
       description: IMSI identifying this UE.
     key:
       type: string
@@ -63,6 +63,10 @@ config:
       type: int
       default: 1
       description: Slice Service Type
+    sd:
+      type: string
+      default: "010203"
+      description: Slice Differentiator
 
 parts:
   charm:

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,6 +143,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             opc=self._charm_config.opc,
             dnn=self._charm_config.dnn,
             sst=self._charm_config.sst,
+            sd=self._charm_config.sd,
         ).rstrip()
 
     def _is_ue_config_up_to_date(self, content: str) -> bool:
@@ -272,6 +273,7 @@ def _render_config_file(
     opc: str,
     dnn: str,
     sst: int,
+    sd: str,
 ) -> str:
     """Render UE config file based on parameters.
 
@@ -281,6 +283,7 @@ def _render_config_file(
         opc: Secret Key for operator
         dnn: Data Network Name
         sst: Slice Service Type
+        sd: Slice Differentiator
 
     Returns:
         str: Rendered UE configuration file
@@ -293,6 +296,7 @@ def _render_config_file(
         opc=opc,
         dnn=dnn,
         sst=sst,
+        sd=sd,
     )
 
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -56,6 +56,7 @@ class UEConfig(BaseModel):  # pylint: disable=too-few-public-methods
     )
     dnn: StrictStr = Field(default="internet", min_length=1)
     sst: int = Field(ge=1, le=4)
+    sd: StrictStr = Field(default="010203", min_length=1)
 
 
 @dataclasses.dataclass
@@ -68,6 +69,7 @@ class CharmConfig:
         opc: Secret Key for operator
         dnn: Data Network Name
         sst: Slice Service Type
+        sd: Slice Differentiator
     """
 
     imsi: StrictStr
@@ -75,6 +77,7 @@ class CharmConfig:
     opc: StrictStr
     dnn: StrictStr
     sst: int
+    sd: StrictStr
 
     def __init__(self, *, ue_config: UEConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -87,6 +90,7 @@ class CharmConfig:
         self.opc = ue_config.opc
         self.dnn = ue_config.dnn
         self.sst = ue_config.sst
+        self.sd = ue_config.sd
 
     @classmethod
     def from_charm(

--- a/src/templates/ue.conf.j2
+++ b/src/templates/ue.conf.j2
@@ -4,4 +4,5 @@ uicc0 = {
   opc= "{{ opc }}";
   dnn= "{{ dnn }}";
   nssai_sst={{ sst }};
+  nssai_sd="{{ sd }}";
 }

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -1,7 +1,8 @@
 uicc0 = {
-  imsi = "208930100007487";
+  imsi = "001010100007487";
   key = "5122250214c33e723a5dd523fc145fc0";
   opc= "981d464c7c52eb6e5036234984ad0bcf";
   dnn= "internet";
   nssai_sst=1;
+  nssai_sd="010203";
 }

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -35,6 +35,7 @@ class TestCharmCollectStatus(UEFixtures):
             pytest.param("opc", "123abc123abc123abc123abc123abc123abc123abc", id="too_long_opc"),
             pytest.param("dnn", "", id="empty_dnn"),
             pytest.param("sst", int(), id="empty_sst"),
+            pytest.param("sd", "", id="empty_sd"),
         ],
     )
     def test_given_invalid_config_when_collect_status_then_status_is_blocked(


### PR DESCRIPTION
# Description

If the `SD` value is not given, the UE falls back to `FFFFFF` as a default. This causes a mismatch with the default value for the slice which is `010203`. As a result, the UE can't register to the AMF.

This PR allows setting value of the SD. The default is `010203`.
Using the occasion, also the default IMSI was changed to use PLMN of `00101`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library