### PR TITLE
chore: Aligns SD config between the Core and the UE by allowing both decimal and hex values

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -64,11 +64,11 @@ config:
       default: 1
       description: Slice Service Type
     sd:
-      type: int
-      default: 102030
+      type: string
+      default: "0x102030"
       description: |
         Slice Differentiator
-        It needs to be an integer between 0 and 16777215 with even number of digits.
+        It needs to be a number between 0 and 16777215 or its hex representation. Hex value needs to be prefixed with `0x`.
 
 parts:
   charm:

--- a/src/charm.py
+++ b/src/charm.py
@@ -273,7 +273,7 @@ def _render_config_file(
     opc: str,
     dnn: str,
     sst: int,
-    sd: int,
+    sd: str,
 ) -> str:
     """Render UE config file based on parameters.
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -58,13 +58,14 @@ class UEConfig(BaseModel):  # pylint: disable=too-few-public-methods
     )
     dnn: StrictStr = Field(default="internet", min_length=1)
     sst: int = Field(ge=1, le=4)
-    sd: int = Field(default=102030, ge=0, le=16777215)
+    sd: StrictStr = Field(default="0x102030")
 
     @field_validator("sd", mode="before")
     @classmethod
     def validate_sd(cls, value: str, info: ValidationInfo) -> str:
-        """Make sure Slice Differentiator has an even number of digits."""
-        if not len(str(value)) % 2 == 0:
+        """Make sure Slice Differentiator is valid."""
+        sd_int = int(value, 0)
+        if not 0 <= sd_int <= 16777215:
             raise ValueError()
         return value
 
@@ -87,7 +88,7 @@ class CharmConfig:
     opc: StrictStr
     dnn: StrictStr
     sst: int
-    sd: int
+    sd: StrictStr
 
     def __init__(self, *, ue_config: UEConfig):
         """Initialize a new instance of the CharmConfig class.

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -4,5 +4,5 @@ uicc0 = {
   opc= "981d464c7c52eb6e5036234984ad0bcf";
   dnn= "internet";
   nssai_sst=1;
-  nssai_sd=102030;
+  nssai_sd=0x102030;
 }

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -35,9 +35,9 @@ class TestCharmCollectStatus(UEFixtures):
             pytest.param("opc", "123abc123abc123abc123abc123abc123abc123abc", id="too_long_opc"),
             pytest.param("dnn", "", id="empty_dnn"),
             pytest.param("sst", int(), id="empty_sst"),
-            pytest.param("sd", int(), id="empty_sd"),
-            pytest.param("sd", 123, id="sd_odd_number_of_digits"),
-            pytest.param("sd", 123123123, id="sd_out_or_range"),
+            pytest.param("sd", "", id="empty_sd"),
+            pytest.param("sd", "0xfffffff", id="hex_sd_out_or_range"),
+            pytest.param("sd", "123123123", id="sd_out_or_range"),
         ],
     )
     def test_given_invalid_config_when_collect_status_then_status_is_blocked(


### PR DESCRIPTION
# Description

Allows configuring the SD as both decimal or hex string.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library