### PR TITLE
feat: Adds start-simulation action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -70,6 +70,12 @@ config:
         Slice Differentiator
         It needs to be a number between 0 and 16777215 or its hex representation. Hex value needs to be prefixed with `0x`.
 
+actions:
+  start-simulation:
+    description: |
+      Starts the network traffic simulation.
+      This action runs a `ping` against 8.8.8.8 (Google DNS) to make sure all the network components work correctly. 
+
 parts:
   charm:
     build-packages:

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ from ops import (
 )
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
+from ops.model import ModelError
 from ops.pebble import ExecError, Layer
 
 from charm_config import CharmConfig, CharmConfigInvalidError
@@ -146,6 +147,11 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         """
         if not self._container.can_connect():
             event.fail(message="Container is not ready")
+            return
+        try:
+            self._container.get_service(self._service_name)
+        except ModelError:
+            event.fail(message="UE service is not ready")
             return
         try:
             stdout, _ = self._exec_command_in_workload(command="ping -I oaitun_ue1 8.8.8.8 -c 10")

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -5,11 +5,81 @@
 import tempfile
 
 import scenario
-
+from ops.pebble import Layer, ServiceStatus
 from tests.unit.fixtures import UEFixtures
 
 
 class TestCharmConfigure(UEFixtures):
+    def test_given_ue_container_not_available_when_start_simulation_action_then_action_status_is_failed(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = scenario.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data={
+                    "rfsim_address": "1.1.1.1",
+                },
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="ue",
+                can_connect=False,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+            )
+
+            action_results = self.ctx.run_action("start-simulation", state_in)
+
+            assert not action_results.success
+            assert action_results.failure
+            assert action_results.failure == "Container is not ready"
+
+    def test_given_ue_service_not_ready_when_start_simulation_action_then_action_status_is_failed(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = scenario.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data={
+                    "rfsim_address": "1.1.1.1",
+                },
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+            )
+
+            action_results = self.ctx.run_action("start-simulation", state_in)
+
+            assert not action_results.success
+            assert action_results.failure
+            assert action_results.failure == "UE service is not ready"
+
     def test_given_ping_transmits_packets_correctly_when_start_simulation_action_then_action_status_is_successful(  # noqa: E501
         self,
     ):
@@ -30,6 +100,8 @@ class TestCharmConfigure(UEFixtures):
             container = scenario.Container(
                 name="ue",
                 can_connect=True,
+                layers={"ue": Layer({"services": {"ue": {}}})},
+                service_status={"ue": ServiceStatus.ACTIVE},
                 mounts={
                     "config": config_mount,
                 },
@@ -50,8 +122,9 @@ class TestCharmConfigure(UEFixtures):
             action_results = self.ctx.run_action("start-simulation", state_in)
 
             assert action_results.success
-            assert action_results.results["success"] == "true"  # type: ignore[reportOptionalSubscript]  # noqa: E501
-            assert action_results.results["result"] == test_successful_stdout  # type: ignore[reportOptionalSubscript]  # noqa: E501
+            assert action_results.results
+            assert action_results.results["success"] == "true"
+            assert action_results.results["result"] == test_successful_stdout
 
     def test_given_ping_doesnt_transmit_packets_correctly_when_start_simulation_action_then_action_status_is_failed(  # noqa: E501
         self,
@@ -72,6 +145,8 @@ class TestCharmConfigure(UEFixtures):
             container = scenario.Container(
                 name="ue",
                 can_connect=True,
+                layers={"ue": Layer({"services": {"ue": {}}})},
+                service_status={"ue": ServiceStatus.ACTIVE},
                 mounts={
                     "config": config_mount,
                 },
@@ -92,4 +167,5 @@ class TestCharmConfigure(UEFixtures):
             action_results = self.ctx.run_action("start-simulation", state_in)
 
             assert not action_results.success
-            assert "Failed to execute simulation:" in action_results.failure  # type: ignore[reportOperatorIssue]  # noqa: E501
+            assert action_results.failure
+            assert "Failed to execute simulation:" in action_results.failure

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import tempfile
+
+import scenario
+
+from tests.unit.fixtures import UEFixtures
+
+
+class TestCharmConfigure(UEFixtures):
+    def test_given_ping_transmits_packets_correctly_when_start_simulation_action_then_action_status_is_successful(  # noqa: E501
+        self,
+    ):
+        test_successful_stdout = "10 packets transmitted, 10 received, 0% packet loss, time 9012ms"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = scenario.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data={
+                    "rfsim_address": "1.1.1.1",
+                },
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ping", "-I", "oaitun_ue1", "8.8.8.8", "-c", "10"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout=test_successful_stdout,
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+            )
+
+            action_results = self.ctx.run_action("start-simulation", state_in)
+
+            assert action_results.success
+            assert action_results.results["success"] == "true"  # type: ignore[reportOptionalSubscript]  # noqa: E501
+            assert action_results.results["result"] == test_successful_stdout  # type: ignore[reportOptionalSubscript]  # noqa: E501
+
+    def test_given_ping_doesnt_transmit_packets_correctly_when_start_simulation_action_then_action_status_is_failed(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = scenario.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data={
+                    "rfsim_address": "1.1.1.1",
+                },
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ping", "-I", "oaitun_ue1", "8.8.8.8", "-c", "10"): scenario.ExecOutput(
+                        return_code=1,
+                        stdout="10 packets transmitted, 0 received, 100% packet loss, time 9012ms",
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+            )
+
+            action_results = self.ctx.run_action("start-simulation", state_in)
+
+            assert not action_results.success
+            assert "Failed to execute simulation:" in action_results.failure  # type: ignore[reportOperatorIssue]  # noqa: E501

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -6,6 +6,7 @@ import tempfile
 
 import scenario
 from ops.pebble import Layer, ServiceStatus
+
 from tests.unit.fixtures import UEFixtures
 
 


### PR DESCRIPTION
# Description

Adds `start-simulation` action to make testing more convenient.
The action tries to ping Google DNS (8.8.8.8) using the UE interface (oaitun_ue1).

Successful simulation:
```
ubuntu@ip-172-31-9-157:~$ juju run ue/0 start-simulation
Running operation 21 with 1 task
  - task 22 on unit-ue-0

Waiting for task 22...
result: |
  PING 8.8.8.8 (8.8.8.8) from 172.250.0.8 oaitun_ue1: 56(84) bytes of data.
  64 bytes from 8.8.8.8: icmp_seq=1 ttl=116 time=12.4 ms
  64 bytes from 8.8.8.8: icmp_seq=2 ttl=116 time=14.3 ms
  64 bytes from 8.8.8.8: icmp_seq=3 ttl=116 time=6.68 ms
  64 bytes from 8.8.8.8: icmp_seq=4 ttl=116 time=15.3 ms
  64 bytes from 8.8.8.8: icmp_seq=5 ttl=116 time=5.59 ms
  64 bytes from 8.8.8.8: icmp_seq=6 ttl=116 time=14.2 ms
  64 bytes from 8.8.8.8: icmp_seq=7 ttl=116 time=13.8 ms
  64 bytes from 8.8.8.8: icmp_seq=8 ttl=116 time=12.9 ms
  64 bytes from 8.8.8.8: icmp_seq=9 ttl=116 time=13.7 ms
  64 bytes from 8.8.8.8: icmp_seq=10 ttl=116 time=12.2 ms

  --- 8.8.8.8 ping statistics ---
  10 packets transmitted, 10 received, 0% packet loss, time 9011ms
  rtt min/avg/max/mdev = 5.593/12.112/15.347/3.122 ms
success: "True"
```

Failed simulation:
```
ubuntu@ip-172-31-9-157:~$ juju run ue/0 start-simulation
Running operation 19 with 1 task
  - task 20 on unit-ue-0

Waiting for task 20...
Action id 20 failed: Failed to execute simulation: PING 1.2.3.4 (1.2.3.4) from 172.250.0.7 oaitun_ue1: 56(84) bytes of data.

--- 1.2.3.4 ping statistics ---
10 packets transmitted, 0 received, 100% packet loss, time 9200ms
```


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library