### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -5,7 +5,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import OaiRanUeK8SOperatorCharm
 
@@ -26,6 +26,6 @@ class UEFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=OaiRanUeK8SOperatorCharm,
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,7 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from tests.unit.fixtures import UEFixtures
@@ -13,7 +13,7 @@ from tests.unit.fixtures import UEFixtures
 
 class TestCharmCollectStatus(UEFixtures):
     def test_given_unit_is_not_leader_when_collect_status_then_status_is_blocked(self):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 
@@ -43,7 +43,7 @@ class TestCharmCollectStatus(UEFixtures):
     def test_given_invalid_config_when_collect_status_then_status_is_blocked(
         self, config_param, value
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={config_param: value},
         )
@@ -60,16 +60,16 @@ class TestCharmCollectStatus(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[],
                 containers=[container],
@@ -87,21 +87,21 @@ class TestCharmCollectStatus(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={},
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
@@ -112,11 +112,11 @@ class TestCharmCollectStatus(UEFixtures):
             assert state_out.unit_status == WaitingStatus("Waiting for RFSIM information")
 
     def test_given_cant_connect_to_container_when_collect_status_then_status_is_waiting(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="ue",
             can_connect=False,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[],
             containers=[container],
@@ -128,11 +128,11 @@ class TestCharmCollectStatus(UEFixtures):
 
     def test_given_pod_address_not_available_when_collect_status_then_status_is_waiting(self):
         self.mock_check_output.return_value = b""
-        container = scenario.Container(
+        container = testing.Container(
             name="ue",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[],
             containers=[container],
@@ -147,11 +147,11 @@ class TestCharmCollectStatus(UEFixtures):
     ):
         self.mock_k8s_privileged.is_patched.return_value = False
         self.mock_check_output.return_value = b"1.2.3.4"
-        container = scenario.Container(
+        container = testing.Container(
             name="ue",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[],
             containers=[container],
@@ -163,18 +163,18 @@ class TestCharmCollectStatus(UEFixtures):
 
     def test_given_config_file_doesnt_exist_when_collect_status_then_status_is_waiting(self):
         self.mock_check_output.return_value = b"1.2.3.4"
-        rfsim_relation = scenario.Relation(
+        rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
                 "rfsim_address": "1.1.1.1",
             },
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="ue",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[rfsim_relation],
             containers=[container],
@@ -187,25 +187,25 @@ class TestCharmCollectStatus(UEFixtures):
     def test_given_all_prerequisites_met_when_collect_status_then_status_is_active(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -6,7 +6,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.fixtures import UEFixtures
@@ -19,16 +19,16 @@ class TestCharmConfigure(UEFixtures):
         with tempfile.TemporaryDirectory() as tmpdir:
             self.mock_k8s_privileged.is_patched.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 mounts={"config": config_mount},
                 can_connect=True,
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[],
@@ -43,29 +43,29 @@ class TestCharmConfigure(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -83,22 +83,22 @@ class TestCharmConfigure(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             with open("tests/unit/resources/expected_config.conf") as expected_config_file:
                 expected_config = expected_config_file.read().strip()
@@ -115,29 +115,29 @@ class TestCharmConfigure(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -163,27 +163,27 @@ class TestCharmConfigure(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={},
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -5,7 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.pebble import Layer, ServiceStatus
 from ops.testing import ActionFailed
 
@@ -18,25 +18,25 @@ class TestCharmSimulationAction(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=False,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
@@ -52,25 +52,25 @@ class TestCharmSimulationAction(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
@@ -87,18 +87,18 @@ class TestCharmSimulationAction(UEFixtures):
         test_successful_stdout = "10 packets transmitted, 10 received, 0% packet loss, time 9012ms"
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 layers={"ue": Layer({"services": {"ue": {}}})},
@@ -107,7 +107,7 @@ class TestCharmSimulationAction(UEFixtures):
                     "config": config_mount,
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ping", "-I", "oaitun_ue1", "8.8.8.8", "-c", "10"],
                         return_code=0,
                         stdout=test_successful_stdout,
@@ -115,7 +115,7 @@ class TestCharmSimulationAction(UEFixtures):
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],
@@ -131,18 +131,18 @@ class TestCharmSimulationAction(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
                     "rfsim_address": "1.1.1.1",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="ue",
                 can_connect=True,
                 layers={"ue": Layer({"services": {"ue": {}}})},
@@ -151,7 +151,7 @@ class TestCharmSimulationAction(UEFixtures):
                     "config": config_mount,
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ping", "-I", "oaitun_ue1", "8.8.8.8", "-c", "10"],
                         return_code=1,
                         stdout="10 packets transmitted, 0 received, 100% packet loss, time 9012ms",
@@ -159,7 +159,7 @@ class TestCharmSimulationAction(UEFixtures):
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[rfsim_relation],
                 containers=[container],


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we use ops.testing instead of directly calling scenario. Both have the same API. scenario still needs to be independently installed.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library