### PR TITLE
fix: Fixes startup params

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -264,7 +264,6 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
                 "3924180000",
                 "--ssb",
                 "196",
-                "-E",
                 "--band",
                 "77",
                 "--log_config.global_log_options",

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -150,7 +150,7 @@ class TestCharmConfigure(UEFixtures):
                             "ue": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf --sa --rfsim -r 51 --numerology 1 -C 3924180000 --ssb 196 -E --band 77 --log_config.global_log_options level,nocolor,time --rfsimulator.serveraddr 1.1.1.1",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf --sa --rfsim -r 51 --numerology 1 -C 3924180000 --ssb 196 --band 77 --log_config.global_log_options level,nocolor,time --rfsimulator.serveraddr 1.1.1.1",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }


### PR DESCRIPTION
# Description

Adjusts simulator startup command to the DU changes introduced in [DU PR #46](https://github.com/canonical/oai-ran-du-k8s-operator/pull/46)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library