### PR TITLE
feat: Uses params from the fiveg_rfsim relation data to configure UE

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -458,7 +458,11 @@ class RFSIMRequires(Object):
         if not relation.app:
             logger.warning("No remote application in relation: %s", self.relation_name)
             return None
-        return int(dict(relation.data[relation.app]).get("version", ""))
+        try:
+            return int(dict(relation.data[relation.app]).get("version", ""))
+        except ValueError:
+            logger.error("Invalid or missing `fiveg_rfsim` provider interface version.")
+            return None
 
     def get_provider_rfsim_information(
         self, relation: Optional[Relation] = None

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -5,9 +5,9 @@
 
 This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
 
-The purpose of this library is to relate two charms to pass the RF SIM address and network information (SST and SD).
-In the Telco world this will typically be charms implementing
-the DU (Distributed Unit) and the UE (User equipment).
+The purpose of this library is to relate two charms to pass the network configuration data required to start the RF simulation.
+In particular the RF SIM address, Network Slice Type (SST), Slice Differentiator (SD), RF band, downlink frequency, carrier bandwidth, numerology and the number of the first usable subcarrier will be passed through the interface.
+In the Telco world this will typically be charms implementing the DU (Distributed Unit) and the UE (User equipment).
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
@@ -21,7 +21,7 @@ Add the following libraries to the charm's `requirements.txt` file:
 - pytest-interface-tester
 
 ### Provider charm
-The provider charm is the one providing the information about RF SIM address, Network Slice Type (SST) and Network Differentiator (SD).
+The provider charm is the one providing the information about RF SIM address, SST, SD, RF band, downlink frequency, carrier bandwidth, numerology and the number of the first usable subcarrier.
 Typically, this will be the DU charm.
 
 Example:
@@ -38,6 +38,11 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
     RFSIM_ADDRESS = "192.168.70.130"
     SST = 1
     SD = 1
+    BAND = 77
+    DL_FREQ = 4059090000  # In Hz
+    CARRIER_BANDWIDTH = 106  # In PRBs
+    NUMEROLOGY = 1
+    START_SUBCARRIER = 541
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -49,9 +54,15 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
     def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         if self.unit.is_leader():
             self.rfsim_provider.set_rfsim_information(
-                rfsim_address=self.RFSIM_ADDRESS
+                version=0,
+                rfsim_address=self.RFSIM_ADDRESS,
                 sst=self.SST,
                 sd=self.SD,
+                band=self.BAND,
+                dl_freq=self.DL_FREQ,
+                carrier_bandwidth=self.CARRIER_BANDWIDTH,
+                numerology=self.NUMEROLOGY,
+                start_subcarrier=self.START_SUBCARRIER
             )
 
 
@@ -86,8 +97,13 @@ class DummyFivegRFSIMRequires(CharmBase):
     def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         provider_rfsim_address = event.rfsim_address
         provider_sst = event.sst
-        provider_st = event.sd
-        <do something with the rfsim address, SST and SD here>
+        provider_sd = event.sd
+        provider_band = event.band
+        provider_dl_freq = event.dl_freq
+        provider_carrier_bandwidth = event.carrier_bandwidth
+        provider_numerology = event.numerology
+        provider_start_subcarrier = event.start_subcarrier
+        <do something with the received data>
 
 
 if __name__ == "__main__":
@@ -115,7 +131,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -128,19 +144,32 @@ Examples:
     ProviderSchema:
         unit: <empty>
         app: {
+            "version": 0,
             "rfsim_address": "192.168.70.130",
             "sst": 1,
             "sd": 1,
+            "band": 77,
+            "dl_freq": 4059090000,
+            "carrier_bandwidth": 106,
+            "numerology": 1,
+            "start_subcarrier": 541,
         }
     RequirerSchema:
         unit: <empty>
-        app:  <empty>
+        app: {
+            "version": 0,
+        }
 """
 
 
 class ProviderAppData(BaseModel):
     """Provider app data for fiveg_rfsim."""
 
+    version: int = Field(
+        description="Interface version",
+        examples=[0, 1, 2, 3],
+        ge=0,
+    )
     rfsim_address: IPvAnyAddress = Field(
         description="RF simulator service address which is equal to DU pod ip",
         examples=["192.168.70.130"],
@@ -158,12 +187,60 @@ class ProviderAppData(BaseModel):
         ge=0,
         le=16777215,
     )
+    band: int = Field(
+        description="Frequency band",
+        default=None,
+        examples=[34, 77, 102],
+        gt=0,
+    )
+    dl_freq: int = Field(
+        description="Downlink frequency in Hz",
+        default=None,
+        examples=[4059090000],
+        ge=410000000,
+    )
+    carrier_bandwidth: int = Field(
+        description="Carrier bandwidth (number of downlink PRBs)",
+        default=None,
+        examples=[106],
+        ge=11,
+        le=273,
+    )
+    numerology: int = Field(
+        description="Numerology",
+        default=None,
+        examples=[0, 1, 2, 3],
+        ge=0,
+        le=6,
+    )
+    start_subcarrier: int = Field(
+        description="First usable subcarrier",
+        default=None,
+        examples=[530, 541],
+        ge=0,
+    )
 
 
 class ProviderSchema(DataBagSchema):
     """Provider schema for the fiveg_rfsim interface."""
 
     app_data: ProviderAppData
+
+
+class RequirerAppData(BaseModel):
+    """Requirer app data for fiveg_rfsim."""
+
+    version: int = Field(
+        description="Interface version",
+        examples=[0, 1, 2, 3],
+        ge=0,
+    )
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for the fiveg_rfsim interface."""
+
+    app_data: RequirerAppData
 
 
 def provider_data_is_valid(data: Dict[str, Any]) -> bool:
@@ -200,13 +277,28 @@ class RFSIMProvides(Object):
         self.relation_name = relation_name
         self.charm = charm
 
-    def set_rfsim_information(self, rfsim_address: str, sst: int, sd: Optional[int]) -> None:
+    def set_rfsim_information(
+        self,
+        rfsim_address: str,
+        sst: int,
+        sd: Optional[int],
+        band: int,
+        dl_freq: int,
+        carrier_bandwidth: int,
+        numerology: int,
+        start_subcarrier: int,
+    ) -> None:
         """Push the information about the RFSIM interface in the application relation data.
 
         Args:
             rfsim_address (str): rfsim service address which is equal to DU pod ip.
             sst (int): Slice/Service Type
             sd (Optional[int]): Slice Differentiator
+            band (int): Valid 5G band
+            dl_freq (int): Downlink frequency in Hz
+            carrier_bandwidth (int): Carrier bandwidth (number of downlink PRBs)
+            numerology (int): Numerology
+            start_subcarrier (int): First usable subcarrier
         """
         if not self.charm.unit.is_leader():
             raise FivegRFSIMError("Unit must be leader to set application relation data.")
@@ -214,21 +306,37 @@ class RFSIMProvides(Object):
         if not relations:
             raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
         if not provider_data_is_valid(
-            {
-                "rfsim_address": rfsim_address,
-                "sst": sst,
-                "sd": sd,
-            }
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": rfsim_address,
+                    "sst": sst,
+                    "sd": sd,
+                    "band": band,
+                    "dl_freq": dl_freq,
+                    "carrier_bandwidth": carrier_bandwidth,
+                    "numerology": numerology,
+                    "start_subcarrier": start_subcarrier,
+                }
         ):
             raise FivegRFSIMError("Invalid relation data")
         for relation in relations:
             data = {
+                "version": str(LIBAPI),
                 "rfsim_address": rfsim_address,
                 "sst": str(sst),
+                "band": str(band),
+                "dl_freq": str(dl_freq),
+                "carrier_bandwidth": str(carrier_bandwidth),
+                "numerology": str(numerology),
+                "start_subcarrier": str(start_subcarrier),
             }
             if sd is not None:
                 data["sd"] = str(sd)
             relation.data[self.charm.app].update(data)
+
+    @property
+    def interface_version(self):
+        return LIBAPI
 
 
 class RFSIMRequires(Object):
@@ -239,6 +347,15 @@ class RFSIMRequires(Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
+
+    @property
+    def provider_interface_version(self) -> Optional[int]:
+        """Return interface version used by the provider.
+
+        Returns:
+            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+        """
+        return self._get_provider_interface_version()
 
     @property
     def rfsim_address(self) -> Optional[IPvAnyAddress]:
@@ -273,7 +390,78 @@ class RFSIMRequires(Object):
             return remote_app_relation_data.sd
         return None
 
-    def get_provider_rfsim_information(self, relation: Optional[Relation] = None
+    @property
+    def band(self) -> Optional[int]:
+        """Return the RF Band number.
+
+        Returns:
+           Optional[int] : band (RF Band number)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.band
+        return None
+
+    @property
+    def dl_freq(self) -> Optional[int]:
+        """Return the Downlink frequency.
+
+        Returns:
+           Optional[int] : dl_freq (Downlink frequency)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.dl_freq
+        return None
+
+    @property
+    def carrier_bandwidth(self) -> Optional[int]:
+        """Return the carrier bandwidth (number of downlink PRBs).
+
+        Returns:
+           Optional[int] : carrier_bandwidth (carrier bandwidth)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.carrier_bandwidth
+        return None
+
+    @property
+    def numerology(self) -> Optional[int]:
+        """Return numerology.
+
+        Returns:
+           Optional[int] : numerology
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.numerology
+        return None
+
+    @property
+    def start_subcarrier(self) -> Optional[int]:
+        """Return number of the first usable subcarrier.
+
+        Returns:
+           Optional[int] : start_subcarrier
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.start_subcarrier
+        return None
+
+    def _get_provider_interface_version(self) -> Optional[int]:
+        """Get provider interface version.
+
+        Returns:
+            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+        return int(dict(relation.data[relation.app]).get("version", ""))
+
+    def get_provider_rfsim_information(
+        self, relation: Optional[Relation] = None
     ) -> Optional[ProviderAppData]:
         """Get relation data for the remote application.
 
@@ -295,6 +483,17 @@ class RFSIMRequires(Object):
 
         try:
             remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
+            remote_app_relation_data["band"] = int(remote_app_relation_data.get("band", ""))
+            remote_app_relation_data["dl_freq"] = int(remote_app_relation_data.get("dl_freq", ""))
+            remote_app_relation_data["carrier_bandwidth"] = int(
+                remote_app_relation_data.get("carrier_bandwidth", "")
+            )
+            remote_app_relation_data["numerology"] = int(
+                remote_app_relation_data.get("numerology", "")
+            )
+            remote_app_relation_data["start_subcarrier"] = int(
+                remote_app_relation_data.get("start_subcarrier", "")
+            )
         except ValueError as err:
             logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
             return None

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -131,7 +131,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 1
 
 
 logger = logging.getLogger(__name__)
@@ -306,17 +306,17 @@ class RFSIMProvides(Object):
         if not relations:
             raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
         if not provider_data_is_valid(
-                {
-                    "version": str(LIBAPI),
-                    "rfsim_address": rfsim_address,
-                    "sst": sst,
-                    "sd": sd,
-                    "band": band,
-                    "dl_freq": dl_freq,
-                    "carrier_bandwidth": carrier_bandwidth,
-                    "numerology": numerology,
-                    "start_subcarrier": start_subcarrier,
-                }
+            {
+                "version": str(LIBAPI),
+                "rfsim_address": rfsim_address,
+                "sst": sst,
+                "sd": sd,
+                "band": band,
+                "dl_freq": dl_freq,
+                "carrier_bandwidth": carrier_bandwidth,
+                "numerology": numerology,
+                "start_subcarrier": start_subcarrier,
+            }
         ):
             raise FivegRFSIMError("Invalid relation data")
         for relation in relations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from subprocess import check_output
 from typing import Optional, Tuple
 
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMRequires
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI, RFSIMRequires
 from jinja2 import Environment, FileSystemLoader
 from ops import (
     ActiveStatus,
@@ -110,7 +110,31 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             logger.info("Waiting for USB device to be mounted")
             return
         if self._relation_created(RFSIM_RELATION_NAME) and (
-            not self.rfsim_requirer.sst or not self.rfsim_requirer.sd
+            self.rfsim_requirer.provider_interface_version != LIBAPI
+        ):
+            event.add_status(
+                BlockedStatus(
+                    "Can't establish communication over the `fiveg_rfsim` "
+                    "interface due to version mismatch!"
+                )
+            )
+            logger.error(
+                "Can't establish communication over the `fiveg_rfsim` interface "
+                "due to version mismatch!"
+            )
+            return
+        if self._relation_created(RFSIM_RELATION_NAME) and (
+            not all(
+                [
+                    self.rfsim_requirer.sst,
+                    self.rfsim_requirer.sd,
+                    self.rfsim_requirer.band,
+                    self.rfsim_requirer.dl_freq,
+                    self.rfsim_requirer.numerology,
+                    self.rfsim_requirer.carrier_bandwidth,
+                    self.rfsim_requirer.start_subcarrier,
+                ]
+            )
         ):
             event.add_status(WaitingStatus("Waiting for RFSIM information"))
             logger.info("Waiting for RFSIM information")
@@ -148,13 +172,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             return
         if not self._container.exists(path=BASE_CONFIG_PATH):
             return
-        rfsim = all(
-            [
-                self._relation_created(relation_name=RFSIM_RELATION_NAME),
-                self.rfsim_requirer.rfsim_address != "",
-                self.rfsim_requirer.sst != 0,
-            ]
-        )
+        rfsim = self._relation_created(relation_name=RFSIM_RELATION_NAME)
 
         ue_config = self._generate_ue_config()
         if service_restart_required := self._is_ue_config_up_to_date(ue_config):
@@ -305,15 +323,15 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
                     f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                     "--rfsim",
                     "-r",
-                    "106",
+                    str(self.rfsim_requirer.carrier_bandwidth),
                     "--numerology",
-                    "1",
+                    str(self.rfsim_requirer.numerology),
                     "-C",
-                    "3924060000",
+                    str(self.rfsim_requirer.dl_freq),
                     "--ssb",
-                    "530",
+                    str(self.rfsim_requirer.start_subcarrier),
                     "--band",
-                    "77",
+                    str(self.rfsim_requirer.band),
                     "--log_config.global_log_options",
                     "level,nocolor,time",
                     "--rfsimulator.serveraddr",
@@ -328,15 +346,15 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
                 "-O",
                 f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                 "-r",
-                "106",
+                str(self.rfsim_requirer.carrier_bandwidth),
                 "--numerology",
-                "1",
-                "--ssb",
-                "530",
-                "--band",
-                "77",
+                str(self.rfsim_requirer.numerology),
                 "-C",
-                "3924060000",
+                str(self.rfsim_requirer.dl_freq),
+                "--ssb",
+                str(self.rfsim_requirer.start_subcarrier),
+                "--band",
+                str(self.rfsim_requirer.band),
                 "-E",
                 "--log_config.global_log_options",
                 "level,nocolor,time",

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         if self._relation_created(RFSIM_RELATION_NAME) and (
             not all(
                 [
-                    self.rfsim_requirer.provider_interface_version,
+                    self.rfsim_requirer.rfsim_address,
                     self.rfsim_requirer.sst,
                     self.rfsim_requirer.sd,
                     self.rfsim_requirer.band,
@@ -165,6 +165,8 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             and not self._k8s_usb_volume.is_mounted()
         ):
             self._k8s_usb_volume.mount()
+        if self._relation_created(RFSIM_RELATION_NAME):
+            self.rfsim_requirer.set_rfsim_information()
         if self._relation_created(RFSIM_RELATION_NAME) and self._k8s_usb_volume.is_mounted():
             self._k8s_usb_volume.unmount()
         if self._relation_created(relation_name=RFSIM_RELATION_NAME) and (

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,7 +147,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         self.unit.set_workload_version(self._get_workload_version())
         event.add_status(ActiveStatus())
 
-    def _configure(self, _) -> None:
+    def _configure(self, _) -> None:  # noqa: C901
         try:
             self._charm_config: CharmConfig = CharmConfig.from_charm(  # type: ignore[no-redef]  # noqa: E501
                 charm=self

--- a/src/charm.py
+++ b/src/charm.py
@@ -110,22 +110,9 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             logger.info("Waiting for USB device to be mounted")
             return
         if self._relation_created(RFSIM_RELATION_NAME) and (
-            self.rfsim_requirer.provider_interface_version != LIBAPI
-        ):
-            event.add_status(
-                BlockedStatus(
-                    "Can't establish communication over the `fiveg_rfsim` "
-                    "interface due to version mismatch!"
-                )
-            )
-            logger.error(
-                "Can't establish communication over the `fiveg_rfsim` interface "
-                "due to version mismatch!"
-            )
-            return
-        if self._relation_created(RFSIM_RELATION_NAME) and (
             not all(
                 [
+                    self.rfsim_requirer.provider_interface_version,
                     self.rfsim_requirer.sst,
                     self.rfsim_requirer.sd,
                     self.rfsim_requirer.band,
@@ -138,6 +125,20 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         ):
             event.add_status(WaitingStatus("Waiting for RFSIM information"))
             logger.info("Waiting for RFSIM information")
+            return
+        if self._relation_created(RFSIM_RELATION_NAME) and (
+            self.rfsim_requirer.provider_interface_version != LIBAPI
+        ):
+            event.add_status(
+                BlockedStatus(
+                    "Can't establish communication over the `fiveg_rfsim` "
+                    "interface due to version mismatch!"
+                )
+            )
+            logger.error(
+                "Can't establish communication over the `fiveg_rfsim` interface "
+                "due to version mismatch!"
+            )
             return
         if not self._container.exists(path=BASE_CONFIG_PATH):
             event.add_status(WaitingStatus("Waiting for storage to be attached"))

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -205,6 +205,12 @@ async def _deploy_du(ops_test: OpsTest):
         DU_CHARM_NAME,
         application_name=DU_CHARM_NAME,
         channel=DU_CHARM_CHANNEL,
+        config={
+            "bandwidth": 40,
+            "frequency-band": 77,
+            "sub-carrier-spacing": 30,
+            "center-frequency": "4060",
+        },
         trust=True,
     )
     await ops_test.model.integrate(relation1=DU_CHARM_NAME, relation2=CU_CHARM_NAME)

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -95,6 +95,7 @@ class TestCharmCollectStatus(UEFixtures):
                     "version": INVALID_FIVEG_RFSIM_API_VERSION,
                     "rfsim_address": "1.1.1.1",
                     "sst": "1",
+                    "sd": "12555",
                     "band": "77",
                     "dl_freq": "3924060000",
                     "carrier_bandwidth": "106",

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,10 +5,13 @@
 import tempfile
 
 import pytest
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from tests.unit.fixtures import UEFixtures
+
+INVALID_FIVEG_RFSIM_API_VERSION = str(LIBAPI + 1)
 
 
 class TestCharmCollectStatus(UEFixtures):
@@ -78,7 +81,7 @@ class TestCharmCollectStatus(UEFixtures):
 
             assert state_out.unit_status == WaitingStatus("Waiting for USB device to be mounted")
 
-    def test_given_fiveg_rfsim_relation_created_but_rfsim_address_is_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
+    def test_given_fiveg_rfsim_relation_created_but_provider_uses_different_interface_version_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
         self.mock_k8s_usb_volume.is_mounted.return_value = False
@@ -88,7 +91,16 @@ class TestCharmCollectStatus(UEFixtures):
             rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
-                remote_app_data={},
+                remote_app_data={
+                    "version": INVALID_FIVEG_RFSIM_API_VERSION,
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -107,20 +119,111 @@ class TestCharmCollectStatus(UEFixtures):
 
             state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
-            assert state_out.unit_status == WaitingStatus("Waiting for RFSIM information")
+            assert state_out.unit_status == BlockedStatus(
+                "Can't establish communication over the `fiveg_rfsim` "
+                "interface due to version mismatch!"
+            )
 
-    def test_given_fiveg_rfsim_relation_created_rfsim_address_is_available_but_sst_is_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
-        self,
+    @pytest.mark.parametrize(
+        "remote_app_data",
+        [
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+                id="rfsim_address_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+                id="sst_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+                id="band_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "band": "77",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+                id="dl_freq_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+                id="carrier_bandwidth_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "start_subcarrier": "529",
+                },
+                id="numerology_missing",
+            ),
+            pytest.param(
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": "1.1.1.1",
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                },
+                id="start_subcarrier_missing",
+            ),
+        ],
+    )
+    def test_given_fiveg_rfsim_relation_created_but_configuration_parameters_are_missing_from_the_relation_data_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
+        self, remote_app_data
     ):
+        self.mock_k8s_usb_volume.is_mounted.return_value = False
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
             rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
-                remote_app_data={
-                    "rfsim_address": "1.1.1.1",
-                },
+                remote_app_data=remote_app_data,
             )
             config_mount = testing.Mount(
                 source=temp_dir,

--- a/tests/unit/test_charm_ping_action.py
+++ b/tests/unit/test_charm_ping_action.py
@@ -5,6 +5,7 @@
 import tempfile
 
 import pytest
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 from ops.testing import ActionFailed
@@ -13,19 +14,9 @@ from tests.unit.fixtures import UEFixtures
 
 
 class TestCharmPingAction(UEFixtures):
-    def test_given_ue_container_not_available_when_ping_action_then_action_status_is_failed(  # noqa: E501
-        self,
-    ):
+    def test_given_ue_container_not_available_when_ping_action_then_action_status_is_failed(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data={
-                    "rfsim_address": "1.1.1.1",
-                    "sst": "1",
-                },
-            )
             config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
@@ -39,7 +30,6 @@ class TestCharmPingAction(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
                 containers=[container],
             )
 
@@ -48,17 +38,20 @@ class TestCharmPingAction(UEFixtures):
 
             assert exc_info.value.message == "Container is not ready"
 
-    def test_given_ue_service_not_ready_when_ping_action_then_action_status_is_failed(  # noqa: E501
-        self,
-    ):
+    def test_given_ue_service_not_ready_when_ping_action_then_action_status_is_failed(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
             rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
-                    "rfsim_address": "1.1.1.1",
+                    "version": str(LIBAPI),
                     "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
                 },
             )
             config_mount = testing.Mount(
@@ -93,8 +86,13 @@ class TestCharmPingAction(UEFixtures):
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
-                    "rfsim_address": "1.1.1.1",
+                    "version": str(LIBAPI),
                     "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
                 },
             )
             config_mount = testing.Mount(
@@ -138,8 +136,13 @@ class TestCharmPingAction(UEFixtures):
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 remote_app_data={
-                    "rfsim_address": "1.1.1.1",
+                    "version": str(LIBAPI),
                     "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
                 },
             )
             config_mount = testing.Mount(


### PR DESCRIPTION
# Description

Uses params from the `fiveg_rfsim` relation data instead of hardcoded values to configure the UE.
This PR requires the [DU side](https://github.com/canonical/oai-ran-du-k8s-operator/pull/90) to be merged first. After this is done, new version of the `fiveg_rfsim` library needs to be fetched.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library