### PR TITLE
feat: Adds 2x2 MIMO support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .idea

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -63,6 +63,16 @@ config:
     sd:
       type: int
       description: Slice/Service Definition in decimal representation. This value will be transformed into into its hexadecimal representation (1056816 -> `0x102030`). This value is ignored when the `fiveg_rfsim` is used as the SD will be taken from the relation data.
+    use-three-quarter-sampling:
+      type: boolean
+      default: false
+      description: |
+        This parameter enables three-quarter sampling. The value of this parameter should be the same as the value of the corresponding parameter of the DU.
+    use-mimo:
+      type: boolean
+      default: false
+      description: |
+        When set to true enables support for 2x2 MIMO.
 
 actions:
   ping:

--- a/src/charm.py
+++ b/src/charm.py
@@ -318,51 +318,36 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         )
 
     def _get_ue_startup_command(self, rfsim: bool) -> str:
-        if rfsim:
-            return " ".join(
-                [
-                    "/opt/oai-gnb/bin/nr-uesoftmodem",
-                    "-O",
-                    f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
-                    "--rfsim",
-                    "-r",
-                    str(self.rfsim_requirer.carrier_bandwidth),
-                    "--numerology",
-                    str(self.rfsim_requirer.numerology),
-                    "-C",
-                    str(self.rfsim_requirer.dl_freq),
-                    "--ssb",
-                    str(self.rfsim_requirer.start_subcarrier),
-                    "--band",
-                    str(self.rfsim_requirer.band),
-                    "--log_config.global_log_options",
-                    "level,nocolor,time",
-                    "--rfsimulator.serveraddr",
-                    str(self.rfsim_requirer.rfsim_address)
-                    if self.rfsim_requirer.rfsim_address
-                    else "",
-                ]
-            )
-        return " ".join(
-            [
-                "/opt/oai-gnb/bin/nr-uesoftmodem",
-                "-O",
-                f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
-                "-r",
-                str(self.rfsim_requirer.carrier_bandwidth),
-                "--numerology",
-                str(self.rfsim_requirer.numerology),
-                "-C",
-                str(self.rfsim_requirer.dl_freq),
-                "--ssb",
-                str(self.rfsim_requirer.start_subcarrier),
-                "--band",
-                str(self.rfsim_requirer.band),
-                "-E",
-                "--log_config.global_log_options",
-                "level,nocolor,time",
-            ]
-        )
+        ue_startup_command = [
+            "/opt/oai-gnb/bin/nr-uesoftmodem",
+            "-O",
+            f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+            "-r",
+            str(self.rfsim_requirer.carrier_bandwidth),
+            "--numerology",
+            str(self.rfsim_requirer.numerology),
+            "-C",
+            str(self.rfsim_requirer.dl_freq),
+            "--ssb",
+            str(self.rfsim_requirer.start_subcarrier),
+            "--band",
+            str(self.rfsim_requirer.band),
+            "--log_config.global_log_options",
+            "level,nocolor,time",
+            "--rfsim",
+            "--rfsimulator.serveraddr",
+            str(self.rfsim_requirer.rfsim_address),
+        ]
+
+        ue_enable_tree_quarter_sampling_params = ["-E"]
+        ue_enable_mimo_params = ["--ue-nb-ant-tx 2", "--ue-nb-ant-rx 2"]
+
+        if self._charm_config.use_three_quarter_sampling:
+            ue_startup_command += ue_enable_tree_quarter_sampling_params
+        if self._charm_config.use_mimo:
+            ue_startup_command += ue_enable_mimo_params
+
+        return " ".join(ue_startup_command)
 
     def _exec_command_in_workload(self, command: str) -> Tuple[Optional[str], Optional[str]]:
         """Execute command in workload container.

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -70,6 +70,8 @@ class UEConfig(BaseModel):  # pylint: disable=too-few-public-methods
         ge=0,
         le=16777215,
     )
+    use_three_quarter_sampling: bool = False
+    use_mimo: bool = False
 
 
 @dataclasses.dataclass
@@ -83,6 +85,8 @@ class CharmConfig:
         dnn: Data Network Name
         sst: Slice/Service Type
         sd: Slice Differentiator
+        use_three_quarter_sampling: Enable three-quarter sampling rate
+        use_mimo: Enable support for 2x2 MIMO
     """
 
     imsi: StrictStr
@@ -91,6 +95,8 @@ class CharmConfig:
     dnn: StrictStr
     sst: int
     sd: Optional[int]
+    use_three_quarter_sampling: bool
+    use_mimo: bool
 
     def __init__(self, *, ue_config: UEConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -104,6 +110,8 @@ class CharmConfig:
         self.dnn = ue_config.dnn
         self.sst = ue_config.sst
         self.sd = ue_config.sd
+        self.use_three_quarter_sampling = ue_config.use_three_quarter_sampling
+        self.use_mimo = ue_config.use_mimo
 
     @classmethod
     def from_charm(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -315,13 +315,93 @@ class TestCharmConfigure(UEFixtures):
                             "ue": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf --rfsim -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsimulator.serveraddr 1.1.1.1",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsim --rfsimulator.serveraddr 1.1.1.1",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }
                     }
                 )
             }
+
+    def test_given_three_quarter_sampling_enabled_when_configure_then_ue_startup_command_has_correct_params(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_k8s_usb_volume.is_mounted.return_value = False
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"use-three-quarter-sampling": True},
+            )
+
+            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            container = state_out.get_container("ue")
+            ue_pebble_layer = container.layers["ue"].to_dict()
+            ue_startup_command = ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            assert (
+                ue_startup_command
+                == "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsim --rfsimulator.serveraddr 1.1.1.1 -E"  # noqa: E501
+            )
+
+    def test_given_use_mimo_enabled_when_configure_then_ue_startup_command_has_correct_params(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_k8s_usb_volume.is_mounted.return_value = False
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"use-mimo": True},
+            )
+
+            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            container = state_out.get_container("ue")
+            ue_pebble_layer = container.layers["ue"].to_dict()
+            ue_startup_command = ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            assert (
+                ue_startup_command
+                == "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsim --rfsimulator.serveraddr 1.1.1.1 --ue-nb-ant-tx 2 --ue-nb-ant-rx 2"  # noqa: E501
+            )
 
     @pytest.mark.parametrize(
         "remote_app_data",

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -357,7 +357,9 @@ class TestCharmConfigure(UEFixtures):
 
             container = state_out.get_container("ue")
             ue_pebble_layer = container.layers["ue"].to_dict()
-            ue_startup_command = ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            ue_startup_command = (
+                ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            )
             assert (
                 ue_startup_command
                 == "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsim --rfsimulator.serveraddr 1.1.1.1 -E"  # noqa: E501
@@ -397,7 +399,9 @@ class TestCharmConfigure(UEFixtures):
 
             container = state_out.get_container("ue")
             ue_pebble_layer = container.layers["ue"].to_dict()
-            ue_startup_command = ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            ue_startup_command = (
+                ue_pebble_layer.get("services", {}).get("ue", {}).get("command", "")
+            )
             assert (
                 ue_startup_command
                 == "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time --rfsim --rfsimulator.serveraddr 1.1.1.1 --ue-nb-ant-tx 2 --ue-nb-ant-rx 2"  # noqa: E501


### PR DESCRIPTION
# Description

- Adds support for 2x2 MIMO (enabled through the `use_mimo` config option)
- Refactors the way UE startup command is generated

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library