### PR TITLE
chore: Replaces fiveg_rfsim with fiveg_rf_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ juju deploy oai-ran-cu-k8s --trust --channel=2.2/edge
 juju deploy oai-ran-du-k8s --trust --channel=2.2/edge --config simulation-mode=true
 juju deploy oai-ran-ue-k8s --trust --channel=2.2/edge
 juju integrate oai-ran-du-k8s:fiveg_f1 oai-ran-cu-k8s:fiveg_f1
-juju integrate oai-ran-du-k8s:fiveg_rfsim oai-ran-ue-k8s:fiveg_rfsim
+juju integrate oai-ran-du-k8s:fiveg_rf_config oai-ran-ue-k8s:fiveg_rf_config
 ```
 
 ## Image

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -34,8 +34,8 @@ resources:
     upstream-source: ghcr.io/canonical/oai-ran-ue:2.2.0
 
 requires:
-  fiveg_rfsim:
-    interface: fiveg_rfsim
+  fiveg_rf_config:
+    interface: fiveg_rf_config
   logging:
     interface: loki_push_api
 
@@ -57,12 +57,12 @@ config:
       type: string
       default: "internet"
       description: Data Network Name
-    sst:
-      type: int
-      description: Slice/Service Type. This value is ignored when the `fiveg_rfsim` is used as the SST will be taken from the relation data.
-    sd:
-      type: int
-      description: Slice/Service Definition in decimal representation. This value will be transformed into into its hexadecimal representation (1056816 -> `0x102030`). This value is ignored when the `fiveg_rfsim` is used as the SD will be taken from the relation data.
+    simulation-mode:
+      type: boolean
+      default: false
+      description: |
+        Run UE in simulation mode.
+        In the simulation mode, the UE will use emulated over-the-air interface towards the DU/gNB. Simulation mode has been designed to work with the OAI RAN DU/gNB without a need for a license to use an RF band.
     use-three-quarter-sampling:
       type: boolean
       default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,14 +36,6 @@ RF_CONFIG_RELATION_NAME = "fiveg_rf_config"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
 
 
-class UEConfigGenerationError(Exception):
-    """UEConfigGenerationError."""
-
-    def __init__(self, message: str):
-        self.message = message
-        super().__init__(self.message)
-
-
 class OaiRanUeK8SOperatorCharm(CharmBase):
     """Main class to describe Juju event handling for the OAI RAN UE operator for K8s."""
 
@@ -312,8 +304,8 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             command=self._get_ue_startup_command(),
             environment=self._ue_environment_variables,
         )
-        ue_service_layer_dcit = LayerDict(services={self._service_name: ue_service})
-        return Layer(ue_service_layer_dcit)
+        ue_service_layer_dict = LayerDict(services={self._service_name: ue_service})
+        return Layer(ue_service_layer_dict)
 
     def _get_ue_startup_command(self) -> str:
         ue_startup_command = [

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from subprocess import check_output
 from typing import Optional, Tuple
 
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI, RFSIMRequires
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI, RFConfigRequires
 from jinja2 import Environment, FileSystemLoader
 from ops import (
     ActiveStatus,
@@ -22,7 +22,7 @@ from ops import (
 )
 from ops.charm import ActionEvent, CharmBase
 from ops.model import ModelError
-from ops.pebble import ExecError, Layer
+from ops.pebble import ExecError, Layer, LayerDict, ServiceDict
 
 from charm_config import CharmConfig, CharmConfigInvalidError
 from k8s import K8sPrivileged, K8sUSBVolume
@@ -32,8 +32,16 @@ logger = logging.getLogger(__name__)
 BASE_CONFIG_PATH = "/tmp/conf"
 CONFIG_FILE_NAME = "ue.conf"
 LOGGING_RELATION_NAME = "logging"
-RFSIM_RELATION_NAME = "fiveg_rfsim"
+RF_CONFIG_RELATION_NAME = "fiveg_rf_config"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
+
+
+class UEConfigGenerationError(Exception):
+    """UEConfigGenerationError."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
 
 
 class OaiRanUeK8SOperatorCharm(CharmBase):
@@ -47,7 +55,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         self._container_name = self._service_name = "ue"
         self._container = self.unit.get_container(self._container_name)
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
-        self.rfsim_requirer = RFSIMRequires(self, RFSIM_RELATION_NAME)
+        self.rf_config_requires = RFConfigRequires(self, RF_CONFIG_RELATION_NAME)
         self._k8s_privileged = K8sPrivileged(
             namespace=self.model.name, statefulset_name=self.app.name
         )
@@ -66,10 +74,10 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.ue_pebble_ready, self._configure)
-        self.framework.observe(self.on[RFSIM_RELATION_NAME].relation_changed, self._configure)
+        self.framework.observe(self.on[RF_CONFIG_RELATION_NAME].relation_changed, self._configure)
         self.framework.observe(self.on.ping_action, self._on_ping_action)
 
-    def _on_collect_unit_status(self, event: CollectStatusEvent):
+    def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa: C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
 
         Set the workload version if present in workload
@@ -98,51 +106,58 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for Pod IP address to be available"))
             logger.info("Waiting for Pod IP address to be available")
             return
+        if not self._container.exists(path=BASE_CONFIG_PATH):
+            event.add_status(WaitingStatus("Waiting for storage to be attached"))
+            logger.info("Waiting for storage to be attached")
+            return
         if not self._k8s_privileged.is_patched(container_name=self._container_name):
             event.add_status(WaitingStatus("Waiting for statefulset to be patched"))
             logger.info("Waiting for statefulset to be patched")
             return
-        if (
-            not self._relation_created(RFSIM_RELATION_NAME)
-            and not self._k8s_usb_volume.is_mounted()
-        ):
-            event.add_status(WaitingStatus("Waiting for USB device to be mounted"))
-            logger.info("Waiting for USB device to be mounted")
+        if not self._relation_created(RF_CONFIG_RELATION_NAME):
+            event.add_status(BlockedStatus("Waiting for fiveg_rf_config relation to be created"))
+            logger.info("Waiting for fiveg_rf_config relation to be created")
             return
-        if self._relation_created(RFSIM_RELATION_NAME) and (
-            not all(
-                [
-                    self.rfsim_requirer.rfsim_address,
-                    self.rfsim_requirer.sst,
-                    self.rfsim_requirer.sd,
-                    self.rfsim_requirer.band,
-                    self.rfsim_requirer.dl_freq,
-                    self.rfsim_requirer.numerology,
-                    self.rfsim_requirer.carrier_bandwidth,
-                    self.rfsim_requirer.start_subcarrier,
-                ]
-            )
-        ):
-            event.add_status(WaitingStatus("Waiting for RFSIM information"))
-            logger.info("Waiting for RFSIM information")
-            return
-        if self._relation_created(RFSIM_RELATION_NAME) and (
-            self.rfsim_requirer.provider_interface_version != LIBAPI
+        if self._relation_created(RF_CONFIG_RELATION_NAME) and (
+            self.rf_config_requires.provider_interface_version != LIBAPI
         ):
             event.add_status(
                 BlockedStatus(
-                    "Can't establish communication over the `fiveg_rfsim` "
+                    "Can't establish communication over the `fiveg_rf_config` "
                     "interface due to version mismatch!"
                 )
             )
             logger.error(
-                "Can't establish communication over the `fiveg_rfsim` interface "
+                "Can't establish communication over the `fiveg_rf_config` interface "
                 "due to version mismatch!"
             )
             return
-        if not self._container.exists(path=BASE_CONFIG_PATH):
-            event.add_status(WaitingStatus("Waiting for storage to be attached"))
-            logger.info("Waiting for storage to be attached")
+        if not self._charm_config.simulation_mode and not self._k8s_usb_volume.is_mounted():
+            event.add_status(WaitingStatus("Waiting for USB device to be mounted"))
+            logger.info("Waiting for USB device to be mounted")
+            return
+        if self._relation_created(RF_CONFIG_RELATION_NAME) and (
+            not all(
+                [
+                    self.rf_config_requires.sst,
+                    self.rf_config_requires.band,
+                    self.rf_config_requires.dl_freq,
+                    self.rf_config_requires.numerology,
+                    self.rf_config_requires.carrier_bandwidth,
+                    self.rf_config_requires.start_subcarrier,
+                ]
+            )
+        ):
+            event.add_status(WaitingStatus("Waiting for RF configuration"))
+            logger.info("Waiting for RF configuration")
+            return
+        if (
+            self._charm_config.simulation_mode
+            and self._relation_created(RF_CONFIG_RELATION_NAME)
+            and not self.rf_config_requires.rfsim_address
+        ):
+            event.add_status(WaitingStatus("Waiting for RF simulator IP address"))
+            logger.info("Waiting for RF simulator IP address")
             return
         self.unit.set_workload_version(self._get_workload_version())
         event.add_status(ActiveStatus())
@@ -160,17 +175,20 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             return
         if not self._k8s_privileged.is_patched(container_name=self._container_name):
             self._k8s_privileged.patch_statefulset(container_name=self._container_name)
-        if (
-            not self._relation_created(RFSIM_RELATION_NAME)
-            and not self._k8s_usb_volume.is_mounted()
-        ):
+        if not self._charm_config.simulation_mode and not self._k8s_usb_volume.is_mounted():
             self._k8s_usb_volume.mount()
-        if self._relation_created(RFSIM_RELATION_NAME):
-            self.rfsim_requirer.set_rfsim_information()
-        if self._relation_created(RFSIM_RELATION_NAME) and self._k8s_usb_volume.is_mounted():
+        if self._charm_config.simulation_mode and self._k8s_usb_volume.is_mounted():
             self._k8s_usb_volume.unmount()
-        if self._relation_created(relation_name=RFSIM_RELATION_NAME) and (
-            not self.rfsim_requirer.rfsim_address or not self.rfsim_requirer.sst
+        if self._relation_created(RF_CONFIG_RELATION_NAME):
+            self.rf_config_requires.set_rf_config_information()
+        if self._relation_created(relation_name=RF_CONFIG_RELATION_NAME) and (
+            not self.rf_config_requires.sst
+        ):
+            return
+        if (
+            self._charm_config.simulation_mode
+            and self._relation_created(RF_CONFIG_RELATION_NAME)
+            and not self.rf_config_requires.rfsim_address
         ):
             return
         if not self._container.exists(path=BASE_CONFIG_PATH):
@@ -188,18 +206,6 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             # According to TS 23.003, no SD is defined as 0xffffff
             return "0xffffff"
         return hex(value)
-
-    def _get_sst(self) -> Optional[int]:
-        if self._relation_created(RFSIM_RELATION_NAME):
-            return self.rfsim_requirer.sst
-        else:
-            return self._charm_config.sst
-
-    def _get_sd(self) -> Optional[int]:
-        if self._relation_created(RFSIM_RELATION_NAME):
-            return self.rfsim_requirer.sd
-        else:
-            return self._charm_config.sd
 
     def _on_ping_action(self, event: ActionEvent) -> None:
         """Run network traffic simulation.
@@ -228,9 +234,7 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             event.fail(message=f"Failed to execute simulation: {str(e.stdout)}")
 
     def _generate_ue_config(self) -> str:
-        sst = self._get_sst()
-        sd = self._get_sd()
-        if not sst:
+        if not self.rf_config_requires.sst:
             logger.error("SST is not available")
             return ""
         return _render_config_file(
@@ -238,8 +242,8 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             key=self._charm_config.key,
             opc=self._charm_config.opc,
             dnn=self._charm_config.dnn,
-            sst=sst,
-            sd=self.get_sd_as_hex(sd),
+            sst=self.rf_config_requires.sst,
+            sd=self.get_sd_as_hex(self.rf_config_requires.sd),
         ).rstrip()
 
     def _is_ue_config_up_to_date(self, content: str) -> bool:
@@ -302,18 +306,14 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         Returns:
             Layer: Pebble Layer
         """
-        return Layer(
-            {
-                "services": {
-                    self._service_name: {
-                        "override": "replace",
-                        "startup": "enabled",
-                        "command": self._get_ue_startup_command(),
-                        "environment": self._ue_environment_variables,
-                    },
-                },
-            }
+        ue_service = ServiceDict(
+            override="replace",
+            startup="enabled",
+            command=self._get_ue_startup_command(),
+            environment=self._ue_environment_variables,
         )
+        ue_service_layer_dcit = LayerDict(services={self._service_name: ue_service})
+        return Layer(ue_service_layer_dcit)
 
     def _get_ue_startup_command(self) -> str:
         ue_startup_command = [
@@ -321,15 +321,15 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
             "-O",
             f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
             "-r",
-            str(self.rfsim_requirer.carrier_bandwidth),
+            str(self.rf_config_requires.carrier_bandwidth),
             "--numerology",
-            str(self.rfsim_requirer.numerology),
+            str(self.rf_config_requires.numerology),
             "-C",
-            str(self.rfsim_requirer.dl_freq),
+            str(self.rf_config_requires.dl_freq),
             "--ssb",
-            str(self.rfsim_requirer.start_subcarrier),
+            str(self.rf_config_requires.start_subcarrier),
             "--band",
-            str(self.rfsim_requirer.band),
+            str(self.rf_config_requires.band),
             "--log_config.global_log_options",
             "level,nocolor,time",
         ]
@@ -337,12 +337,12 @@ class OaiRanUeK8SOperatorCharm(CharmBase):
         ue_rfsim_params = [
             "--rfsim",
             "--rfsimulator.serveraddr",
-            str(self.rfsim_requirer.rfsim_address),
+            str(self.rf_config_requires.rfsim_address),
         ]
         ue_enable_tree_quarter_sampling_params = ["-E"]
         ue_enable_mimo_params = ["--ue-nb-ant-tx 2", "--ue-nb-ant-rx 2"]
 
-        if self._relation_created(relation_name=RFSIM_RELATION_NAME):
+        if self._charm_config.simulation_mode:
             ue_startup_command += ue_rfsim_params
         if self._charm_config.use_three_quarter_sampling:
             ue_startup_command += ue_enable_tree_quarter_sampling_params

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -6,7 +6,6 @@
 
 import dataclasses
 import logging
-from typing import Optional
 
 import ops
 from pydantic import (  # pylint: disable=no-name-in-module,import-error
@@ -56,20 +55,7 @@ class UEConfig(BaseModel):  # pylint: disable=too-few-public-methods
         min_length=32,
     )
     dnn: StrictStr = Field(default="internet", min_length=1)
-    sst: int = Field(
-        description="Slice/Service Type",
-        examples=[1, 2, 3, 4],
-        ge=0,
-        le=255,
-        default=1,
-    )
-    sd: Optional[int] = Field(
-        description="Slice Differentiator",
-        default=None,
-        examples=[1],
-        ge=0,
-        le=16777215,
-    )
+    simulation_mode: bool = False
     use_three_quarter_sampling: bool = False
     use_mimo: bool = False
 
@@ -83,8 +69,7 @@ class CharmConfig:
         key: Secret Key for USIM
         opc: Secret Key for operator
         dnn: Data Network Name
-        sst: Slice/Service Type
-        sd: Slice Differentiator
+        simulation_mode: Run UE in simulation mode
         use_three_quarter_sampling: Enable three-quarter sampling rate
         use_mimo: Enable support for 2x2 MIMO
     """
@@ -93,8 +78,7 @@ class CharmConfig:
     key: StrictStr
     opc: StrictStr
     dnn: StrictStr
-    sst: int
-    sd: Optional[int]
+    simulation_mode: bool
     use_three_quarter_sampling: bool
     use_mimo: bool
 
@@ -108,8 +92,7 @@ class CharmConfig:
         self.key = ue_config.key
         self.opc = ue_config.opc
         self.dnn = ue_config.dnn
-        self.sst = ue_config.sst
-        self.sd = ue_config.sd
+        self.simulation_mode = ue_config.simulation_mode
         self.use_three_quarter_sampling = ue_config.use_three_quarter_sampling
         self.use_mimo = ue_config.use_mimo
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,7 +8,7 @@ output "app_name" {
 
 output "requires" {
   value = {
-    "fiveg_rfsim" = "fiveg_rfsim"
-    "logging"     = "logging"
+    "fiveg_rf_config" = "fiveg_rf_config"
+    "logging"         = "logging"
   }
 }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import json
 from pathlib import Path
 
@@ -8,6 +9,8 @@ import pytest
 import requests
 import yaml
 from pytest_operator.plugin import OpsTest
+
+from src.charm import RF_CONFIG_RELATION_NAME
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 NMS_MOCK_CHARM_PATH = "./tests/integration/nms_mock_charm.py"
@@ -47,7 +50,9 @@ async def test_relate_and_wait_for_active_status(
     ops_test: OpsTest, deploy_charm_under_test, deploy_dependencies
 ):
     assert ops_test.model
-    await ops_test.model.integrate(relation1=f"{APP_NAME}:fiveg_rfsim", relation2=DU_CHARM_NAME)
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:{RF_CONFIG_RELATION_NAME}", relation2=DU_CHARM_NAME
+    )
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:logging", relation2=GRAFANA_AGENT_CHARM_NAME
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -65,12 +65,12 @@ async def test_relate_and_wait_for_active_status(
 
 
 @pytest.mark.abort_on_fail
-async def test_remove_du_and_wait_for_active_status(
+async def test_remove_du_and_wait_for_blocked_status(
     ops_test: OpsTest, deploy_charm_under_test, deploy_dependencies
 ):
     assert ops_test.model
     await ops_test.model.remove_application(DU_CHARM_NAME, block_until_done=True)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -33,14 +33,14 @@ TIMEOUT = 5 * 60
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_charm_and_wait_for_active_status(
+async def test_deploy_charm_and_wait_for_blocked_status(
     ops_test: OpsTest,
     deploy_charm_under_test,
 ):
     assert ops_test.model
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
-        status="active",
+        status="blocked",
         timeout=TIMEOUT,
     )
 

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -6,14 +6,15 @@ import os
 import tempfile
 
 import pytest
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI
 from ops import testing
 from ops.pebble import Layer
 
+from src.charm import RF_CONFIG_RELATION_NAME
 from tests.unit.fixtures import UEFixtures
 
-INVALID_FIVEG_RFSIM_API_VERSION = str(LIBAPI + 1)
-VALID_RFSIM_REMOTE_DATA_WITHOUT_SD = {
+INVALID_FIVEG_RF_CONFIG_API_VERSION = str(LIBAPI + 1)
+VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD = {
     "version": str(LIBAPI),
     "rfsim_address": "1.1.1.1",
     "sst": "1",
@@ -23,7 +24,16 @@ VALID_RFSIM_REMOTE_DATA_WITHOUT_SD = {
     "numerology": "1",
     "start_subcarrier": "529",
 }
-VALID_RFSIM_REMOTE_DATA_WITH_SD = {
+VALID_NON_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD = {
+    "version": str(LIBAPI),
+    "sst": "1",
+    "band": "77",
+    "dl_freq": "3924060000",
+    "carrier_bandwidth": "106",
+    "numerology": "1",
+    "start_subcarrier": "529",
+}
+VALID_RF_CONFIG_REMOTE_DATA_WITH_SD = {
     "version": str(LIBAPI),
     "rfsim_address": "1.1.1.1",
     "sst": "2",
@@ -69,10 +79,10 @@ class TestCharmConfigure(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
             self.mock_k8s_usb_volume.is_mounted.return_value = False
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -87,7 +97,7 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -110,9 +120,9 @@ class TestCharmConfigure(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={
                     "version": "0",
                     "rfsim_address": "1.1.1.1",
@@ -131,7 +141,7 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -149,10 +159,10 @@ class TestCharmConfigure(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -167,7 +177,7 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -185,16 +195,16 @@ class TestCharmConfigure(UEFixtures):
 
             assert os.stat(temp_dir + "/ue.conf").st_mtime == config_modification_time
 
-    def test_given_ue_config_file_is_up_to_date_when_rfsim_relation_changed_then_ue_config_file_is_not_pushed_to_the_workload_container(  # noqa: E501
+    def test_given_ue_config_file_is_up_to_date_when_rf_config_relation_changed_then_ue_config_file_is_not_pushed_to_the_workload_container(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -209,7 +219,7 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -223,20 +233,20 @@ class TestCharmConfigure(UEFixtures):
 
             config_modification_time = os.stat(temp_dir + "/ue.conf").st_mtime
 
-            self.ctx.run(self.ctx.on.relation_changed(rfsim_relation), state_in)
+            self.ctx.run(self.ctx.on.relation_changed(rf_config_relation), state_in)
 
             assert os.stat(temp_dir + "/ue.conf").st_mtime == config_modification_time
 
-    def test_given_ue_config_exists_when_rfsim_relation_changed_then_new_ue_config_file_is_pushed_to_the_workload_container(  # noqa: E501
+    def test_given_ue_config_exists_when_rf_config_relation_changed_then_new_ue_config_file_is_pushed_to_the_workload_container(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITH_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_RF_CONFIG_REMOTE_DATA_WITH_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -251,7 +261,7 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -264,7 +274,7 @@ class TestCharmConfigure(UEFixtures):
 
             config_modification_time = os.stat(temp_dir + "/ue.conf").st_mtime
 
-            self.ctx.run(self.ctx.on.relation_changed(rfsim_relation), state_in)
+            self.ctx.run(self.ctx.on.relation_changed(rf_config_relation), state_in)
 
             with open(f"{temp_dir}/ue.conf") as updated_config_file:
                 updated_config = updated_config_file.read()
@@ -276,16 +286,16 @@ class TestCharmConfigure(UEFixtures):
 
             assert os.stat(temp_dir + "/ue.conf").st_mtime != config_modification_time
 
-    def test_given_can_connect_when_configure_then_pebble_layer_is_created(
+    def test_given_charm_running_in_simulation_mode_and_can_connect_when_configure_then_pebble_layer_is_created(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -300,7 +310,8 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                config={"simulation-mode": True},
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )
@@ -323,16 +334,16 @@ class TestCharmConfigure(UEFixtures):
                 )
             }
 
-    def test_given_three_quarter_sampling_enabled_when_configure_then_ue_startup_command_has_correct_params(  # noqa: E501
+    def test_given_charm_running_in_non_simulation_mode_and_can_connect_when_configure_then_pebble_layer_is_created(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            self.mock_k8s_usb_volume.is_mounted.return_value = False
+            self.mock_k8s_usb_volume.is_mounted.return_value = True
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_NON_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -347,10 +358,57 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"use-three-quarter-sampling": True},
+            )
+
+            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            container = state_out.get_container("ue")
+            assert container.layers == {
+                "ue": Layer(
+                    {
+                        "services": {
+                            "ue": {
+                                "startup": "enabled",
+                                "override": "replace",
+                                "command": "/opt/oai-gnb/bin/nr-uesoftmodem -O /tmp/conf/ue.conf -r 106 --numerology 1 -C 3924060000 --ssb 529 --band 77 --log_config.global_log_options level,nocolor,time",  # noqa: E501
+                                "environment": {"TZ": "UTC"},
+                            }
+                        }
+                    }
+                )
+            }
+
+    def test_given_three_quarter_sampling_enabled_when_configure_then_ue_startup_command_has_correct_params(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_k8s_usb_volume.is_mounted.return_value = False
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[rf_config_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True, "use-three-quarter-sampling": True},
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -371,10 +429,10 @@ class TestCharmConfigure(UEFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_usb_volume.is_mounted.return_value = False
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data=VALID_RFSIM_REMOTE_DATA_WITHOUT_SD,
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data=VALID_SIMULATION_MODE_RF_CONFIG_REMOTE_DATA_WITHOUT_SD,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -389,10 +447,10 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"use-mimo": True},
+                config={"simulation-mode": True, "use-mimo": True},
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -413,19 +471,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "sst": "1",
-                    "band": "77",
-                    "dl_freq": "3924060000",
-                    "carrier_bandwidth": "106",
-                    "numerology": "1",
-                    "start_subcarrier": "529",
-                },
-                id="rfsim_address_missing",
-            ),
-            pytest.param(
-                {
-                    "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "band": "77",
                     "dl_freq": "3924060000",
                     "carrier_bandwidth": "106",
@@ -437,7 +482,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "sst": "1",
                     "dl_freq": "3924060000",
                     "carrier_bandwidth": "106",
@@ -449,7 +493,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "sst": "1",
                     "band": "77",
                     "carrier_bandwidth": "106",
@@ -461,7 +504,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "sst": "1",
                     "band": "77",
                     "dl_freq": "3924060000",
@@ -473,7 +515,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "sst": "1",
                     "band": "77",
                     "dl_freq": "3924060000",
@@ -485,7 +526,6 @@ class TestCharmConfigure(UEFixtures):
             pytest.param(
                 {
                     "version": str(LIBAPI),
-                    "rfsim_address": "1.1.1.1",
                     "sst": "1",
                     "band": "77",
                     "dl_freq": "3924060000",
@@ -496,14 +536,15 @@ class TestCharmConfigure(UEFixtures):
             ),
         ],
     )
-    def test_given_can_connect_to_the_container_but_configuration_parameters_are_missing_from_the_fiveg_rfsim_relation_data_when_configure_then_pebble_layer_is_not_created(  # noqa: E501
+    def test_given_charm_running_in_non_simulation_mode_and_can_connect_to_the_container_but_configuration_parameters_are_missing_from_the_fiveg_rf_config_relation_data_when_configure_then_pebble_layer_is_not_created(  # noqa: E501
         self, remote_app_data
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_k8s_usb_volume.is_mounted.return_value = True
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data=remote_app_data,
             )
             config_mount = testing.Mount(
@@ -519,7 +560,50 @@ class TestCharmConfigure(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+            )
+
+            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            container = state_out.get_container("ue")
+            assert container.layers == {}
+
+    def test_given_charm_running_in_simulation_mode_and_can_connect_to_the_container_but_rfsim_address_is_missing_from_the_fiveg_rf_config_relation_data_when_configure_then_pebble_layer_is_not_created(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_k8s_usb_volume.is_mounted.return_value = False
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data={
+                    "version": str(LIBAPI),
+                    "sst": "1",
+                    "band": "77",
+                    "dl_freq": "3924060000",
+                    "carrier_bandwidth": "106",
+                    "numerology": "1",
+                    "start_subcarrier": "529",
+                },
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="ue",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                config={"simulation-mode": True},
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
             )

--- a/tests/unit/test_charm_ping_action.py
+++ b/tests/unit/test_charm_ping_action.py
@@ -5,11 +5,12 @@
 import tempfile
 
 import pytest
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 from ops.testing import ActionFailed
 
+from src.charm import RF_CONFIG_RELATION_NAME
 from tests.unit.fixtures import UEFixtures
 
 
@@ -41,9 +42,9 @@ class TestCharmPingAction(UEFixtures):
     def test_given_ue_service_not_ready_when_ping_action_then_action_status_is_failed(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={
                     "version": str(LIBAPI),
                     "sst": "1",
@@ -67,7 +68,7 @@ class TestCharmPingAction(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
             )
 
@@ -82,9 +83,9 @@ class TestCharmPingAction(UEFixtures):
         test_successful_stdout = "10 packets transmitted, 10 received, 0% packet loss, time 9012ms"
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={
                     "version": str(LIBAPI),
                     "sst": "1",
@@ -118,7 +119,7 @@ class TestCharmPingAction(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
             )
 
@@ -132,9 +133,9 @@ class TestCharmPingAction(UEFixtures):
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={
                     "version": str(LIBAPI),
                     "sst": "1",
@@ -168,7 +169,7 @@ class TestCharmPingAction(UEFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
             )
 


### PR DESCRIPTION
# Description

This PR is part of a fix for [TELCO-1730](https://warthogs.atlassian.net/browse/TELCO-1730).

Changes in this PR make use of the new `fiveg_rf_config` interface implemented in the [OAI RAN DU K8s #102](https://github.com/canonical/oai-ran-du-k8s-operator/pull/102). The new interface allows passing the RF configuration to the OAI UE charm regardless of the DU simulation-mode being True or False.

Similarly to the OAI RAN DU K8s operator, this PR introduces a new charm config param, `simulation-mode`, which should be set to `True` if simulated over-the-air interface is to be used. By default, the charm will run in non-simulation mode.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library

[TELCO-1730]: https://warthogs.atlassian.net/browse/TELCO-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ