### PR TITLE
fix: Updates grafana-agent channel to 1/stable

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,6 +20,7 @@ AMF_CHARM_CHANNEL = "1.6/edge"
 DB_CHARM_NAME = "mongodb-k8s"
 DB_CHARM_CHANNEL = "6/stable"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
+GRAFANA_AGENT_CHARM_CHANNEL = "1/stable"
 NRF_CHARM_NAME = "sdcore-nrf-k8s"
 NRF_CHARM_CHANNEL = "1.6/edge"
 CU_CHARM_NAME = "oai-ran-cu-k8s"
@@ -134,7 +135,7 @@ async def _deploy_grafana_agent(ops_test: OpsTest):
     await ops_test.model.deploy(
         GRAFANA_AGENT_CHARM_NAME,
         application_name=GRAFANA_AGENT_CHARM_NAME,
-        channel="stable",
+        channel=GRAFANA_AGENT_CHARM_CHANNEL,
     )
 
 


### PR DESCRIPTION
# Description

Sets `grafana-agent-k8s` channel to `1/stable`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library